### PR TITLE
refactor: modify default config this for support multi databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,34 @@ exports.mongo = {
 };
 ```
 
+### multi database config
+
+> **Can not set client and clients both.**
+
+```js
+// {app_root}/config/config.default.js
+exports.mongo = {
+  clients: {
+    db1: {
+      host: 'host',
+      port: 'port',
+      name: 'db1',
+      user: 'user',
+      password: 'password',
+      option: {},
+    },
+    db2: {
+      host: 'host',
+      port: 'port',
+      name: 'db2',
+      user: 'user',
+      password: 'password',
+      option: {},
+    },
+  },
+};
+```
+
 see [config/config.default.js](config/config.default.js) for more detail.
 
 ## Example
@@ -121,6 +149,13 @@ and with plugin API
 ```js
 const args = { doc, options };
 app.mongo.insertOne('name', args);
+```
+
+multi database
+
+```js
+const args = { doc, options };
+app.mongo.get('db1').insertOne('name', args);
 ```
 
 The `args` is the object provides the arguments to official API.

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -106,6 +106,34 @@ exports.mongo = {
 };
 ```
 
+### 多个 database 配置
+
+> **不能 client 和 clients 都设置，否则会报错。**
+
+```js
+// {app_root}/config/config.default.js
+exports.mongo = {
+  clients: {
+    db1: {
+      host: 'host',
+      port: 'port',
+      name: 'db1',
+      user: 'user',
+      password: 'password',
+      option: {},
+    },
+    db2: {
+      host: 'host',
+      port: 'port',
+      name: 'db2',
+      user: 'user',
+      password: 'password',
+      option: {},
+    },
+  },
+};
+```
+
 请到 [config/config.default.js](config/config.default.js) 查看详细配置项说明。
 
 ## 使用示例
@@ -123,6 +151,13 @@ db.collection('name').insertOne(doc, options);
 ```js
 const args = { doc, options };
 app.mongo.insertOne('name', args);
+```
+
+multi database
+
+```js
+const args = { doc, options };
+app.mongo.get('db1').insertOne('name', args);
 ```
 
 可以看到 `args` 就是包含原版 API 参数的一个对象。

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -6,9 +6,9 @@
  * @property {String} SOME_KEY - some description
  */
 exports.mongo = {
-  client: {
-    host: 'localhost',
+  default: {
     port: 27017,
-    name: 'test',
   },
+  app: true,
+  agent: false,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egg-mongo-native",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "MongoDB egg.js plugin using native driver.",
   "eggPlugin": {
     "name": "mongo"

--- a/test/fixtures/apps/mongo-test/config/config.unittest.js
+++ b/test/fixtures/apps/mongo-test/config/config.unittest.js
@@ -1,9 +1,14 @@
 'use strict';
 
 exports.mongo = {
-  client: {
-    host: 'localhost',
-    port: 27017,
-    name: 'test',
+  clients: {
+    test: {
+      host: 'localhost',
+      name: 'test',
+    },
+    test1: {
+      host: 'localhost',
+      name: 'test1',
+    },
   },
 };

--- a/test/mongo.test.js
+++ b/test/mongo.test.js
@@ -15,18 +15,20 @@ describe('test/mongo.test.js', () => {
   });
 
   afterEach(async () => {
-    await app.mongo.deleteMany('test', {});
+    await app.mongo.get('test').deleteMany('test', {});
+    await app.mongo.get('test1').deleteMany('test', {});
     mm.restore();
   });
 
   after(async () => {
-    await app.mongo.deleteMany('test', {});
+    await app.mongo.get('test').deleteMany('test', {});
+    await app.mongo.get('test1').deleteMany('test', {});
     app.close();
   });
 
   describe('insertOne()', () => {
     it('should insert success', async () => {
-      const result = await app.mongo.insertOne(NAME, {
+      const result = await app.mongo.get('test').insertOne(NAME, {
         doc: { title: 'new doc' },
       });
       assert(result.insertedCount === 1);
@@ -37,7 +39,7 @@ describe('test/mongo.test.js', () => {
     });
 
     it('should insert empty document success', async () => {
-      const result = await app.mongo.insertOne(NAME);
+      const result = await app.mongo.get('test1').insertOne(NAME);
       assert(result.insertedCount === 1);
       assert(typeof result.insertedId === 'string');
       assert(result.value.hasOwnProperty('_id'));
@@ -47,7 +49,7 @@ describe('test/mongo.test.js', () => {
   describe('findOneAndUpdate()', () => {
     let id;
     beforeEach(async () => {
-      const result = await app.mongo.insertMany(NAME, {
+      const result = await app.mongo.get('test').insertMany(NAME, {
         docs: [
           { index: 1, title: 'new doc' },
           { index: 2, title: 'new doc' },
@@ -58,7 +60,7 @@ describe('test/mongo.test.js', () => {
     });
 
     it('should update success', async () => {
-      const result = await app.mongo.findOneAndUpdate(NAME, {
+      const result = await app.mongo.get('test').findOneAndUpdate(NAME, {
         filter: { _id: new ObjectID(id) },
         update: { title: 'update doc' },
       });
@@ -70,7 +72,7 @@ describe('test/mongo.test.js', () => {
     });
 
     it('should update success and return updated', async () => {
-      const result = await app.mongo.findOneAndUpdate(NAME, {
+      const result = await app.mongo.get('test').findOneAndUpdate(NAME, {
         filter: { _id: new ObjectID(id) },
         update: { title: 'update doc' },
         options: { returnOriginal: false },
@@ -83,7 +85,7 @@ describe('test/mongo.test.js', () => {
     });
 
     it('should update success with sort', async () => {
-      const result = await app.mongo.findOneAndUpdate(NAME, {
+      const result = await app.mongo.get('test').findOneAndUpdate(NAME, {
         filter: { _id: new ObjectID(id) },
         update: { title: 'update doc' },
         options: { sort: { _id: 1 } },
@@ -95,7 +97,7 @@ describe('test/mongo.test.js', () => {
     });
 
     it('should update success with empty args', async () => {
-      const result = await app.mongo.findOneAndUpdate(NAME);
+      const result = await app.mongo.get('test').findOneAndUpdate(NAME);
       assert(result.ok === 1);
       assert(result.value.index === 3);
       assert(result.value.title === 'new doc');
@@ -104,7 +106,7 @@ describe('test/mongo.test.js', () => {
     });
 
     it('should upsert success', async () => {
-      const result = await app.mongo.findOneAndUpdate(NAME, {
+      const result = await app.mongo.get('test').findOneAndUpdate(NAME, {
         filter: { title: 'upsert' },
         options: { upsert: true, returnOriginal: false },
       });
@@ -120,13 +122,13 @@ describe('test/mongo.test.js', () => {
     let id;
     beforeEach(
       async () =>
-        ({ insertedId: id } = await app.mongo.insertOne(NAME, {
+        ({ insertedId: id } = await app.mongo.get('test').insertOne(NAME, {
           doc: { title: 'new doc' },
         }))
     );
 
     it('should replace success', async () => {
-      const result = await app.mongo.findOneAndReplace(NAME, {
+      const result = await app.mongo.get('test').findOneAndReplace(NAME, {
         filter: { _id: new ObjectID(id) },
         replacement: { doc: 'replace' },
       });
@@ -137,7 +139,7 @@ describe('test/mongo.test.js', () => {
     });
 
     it('should replace success and return replaced', async () => {
-      const result = await app.mongo.findOneAndReplace(NAME, {
+      const result = await app.mongo.get('test').findOneAndReplace(NAME, {
         filter: { _id: new ObjectID(id) },
         replacement: { doc: 'replace' },
         options: { returnOriginal: false },
@@ -150,7 +152,7 @@ describe('test/mongo.test.js', () => {
     });
 
     it('should replace success with empty args', async () => {
-      const result = await app.mongo.findOneAndReplace(NAME);
+      const result = await app.mongo.get('test').findOneAndReplace(NAME);
       assert(result.ok === 1);
       assert(result.value._id.toString() === id);
       assert(result.value.title === 'new doc');
@@ -159,7 +161,7 @@ describe('test/mongo.test.js', () => {
     });
 
     it('should upsert success', async () => {
-      const result = await app.mongo.findOneAndReplace(NAME, {
+      const result = await app.mongo.get('test').findOneAndReplace(NAME, {
         filter: { title: 'upsert' },
         replacement: { doc: 'replace' },
         options: { upsert: true, returnOriginal: false },
@@ -175,14 +177,14 @@ describe('test/mongo.test.js', () => {
   describe('findOneAndDelete()', () => {
     let id;
     beforeEach(async () => {
-      const result = await app.mongo.insertMany(NAME, {
+      const result = await app.mongo.get('test').insertMany(NAME, {
         docs: [{ title: 'new doc' }, { title: 'new doc' }],
       });
       id = result.insertedIds[0].toString();
     });
 
     it('should delete success', async () => {
-      const result = await app.mongo.findOneAndDelete(NAME, {
+      const result = await app.mongo.get('test').findOneAndDelete(NAME, {
         filter: { _id: new ObjectID(id) },
       });
       assert(result.ok === 1);
@@ -191,7 +193,7 @@ describe('test/mongo.test.js', () => {
     });
 
     it('should delete success with sort', async () => {
-      const result = await app.mongo.findOneAndDelete(NAME, {
+      const result = await app.mongo.get('test').findOneAndDelete(NAME, {
         filter: {},
         options: { sort: { id: 1 } },
       });
@@ -202,7 +204,7 @@ describe('test/mongo.test.js', () => {
     });
 
     it('should delete success with empty filter', async () => {
-      const result = await app.mongo.findOneAndDelete(NAME, { filter: {} });
+      const result = await app.mongo.get('test').findOneAndDelete(NAME, { filter: {} });
       assert(result.ok === 1);
       assert(result.value._id.toString() !== id);
       assert(result.value.title === 'new doc');
@@ -211,7 +213,7 @@ describe('test/mongo.test.js', () => {
 
     it('should replace fail with empty args', async () => {
       try {
-        await app.mongo.findOneAndDelete(NAME);
+        await app.mongo.get('test').findOneAndDelete(NAME);
       } catch (error) {
         assert(error instanceof Error);
       }
@@ -220,7 +222,7 @@ describe('test/mongo.test.js', () => {
 
   describe('insertMany()', () => {
     it('should insert success', async () => {
-      const result = await app.mongo.insertMany(NAME, {
+      const result = await app.mongo.get('test').insertMany(NAME, {
         docs: [{ title: 'doc1' }, { title: 'doc2' }, { title: 'doc3' }],
       });
       assert(result.insertedCount === 3);
@@ -232,7 +234,7 @@ describe('test/mongo.test.js', () => {
 
     it('should insert fail with empty args', async () => {
       try {
-        await app.mongo.insertMany(NAME);
+        await app.mongo.get('test').insertMany(NAME);
       } catch (error) {
         assert(error instanceof Error);
       }
@@ -242,7 +244,7 @@ describe('test/mongo.test.js', () => {
   describe('updateMany()', async () => {
     beforeEach(
       async () =>
-        await app.mongo.insertMany(NAME, {
+        await app.mongo.get('test').insertMany(NAME, {
           docs: [
             { title: 'doc1', type: 'doc' },
             { title: 'doc2', type: 'doc' },
@@ -252,10 +254,10 @@ describe('test/mongo.test.js', () => {
         })
     );
 
-    afterEach(async () => await app.mongo.deleteMany(NAME, {}));
+    afterEach(async () => await app.mongo.get('test').deleteMany(NAME, {}));
 
     it('should update success', async () => {
-      const result = await app.mongo.updateMany(NAME, {
+      const result = await app.mongo.get('test').updateMany(NAME, {
         filter: { type: 'doc' },
         update: { $set: { type: 'update' } },
       });
@@ -266,7 +268,7 @@ describe('test/mongo.test.js', () => {
     });
 
     it('should update success all doc', async () => {
-      const result = await app.mongo.updateMany(NAME, {
+      const result = await app.mongo.get('test').updateMany(NAME, {
         update: { $set: { type: 'update' } },
       });
       assert(result.matchedCount === 4);
@@ -277,7 +279,7 @@ describe('test/mongo.test.js', () => {
 
     it('should update fail with no update', async () => {
       try {
-        await app.mongo.updateMany(NAME, { filter: { type: 'doc' } });
+        await app.mongo.get('test').updateMany(NAME, { filter: { type: 'doc' } });
       } catch (error) {
         assert(error instanceof Error);
       }
@@ -285,14 +287,14 @@ describe('test/mongo.test.js', () => {
 
     it('should update fail with empty args', async () => {
       try {
-        await app.mongo.updateMany(NAME);
+        await app.mongo.get('test').updateMany(NAME);
       } catch (error) {
         assert(error instanceof Error);
       }
     });
 
     it('should upsert success', async () => {
-      const result = await app.mongo.updateMany(NAME, {
+      const result = await app.mongo.get('test').updateMany(NAME, {
         filter: { doc: 'doc5' },
         update: { $set: { type: 'update' } },
         options: { upsert: true },
@@ -308,7 +310,7 @@ describe('test/mongo.test.js', () => {
   describe('deleteMany()', () => {
     beforeEach(
       async () =>
-        await app.mongo.insertMany(NAME, {
+        await app.mongo.get('test').insertMany(NAME, {
           docs: [
             { title: 'doc1', type: 'doc' },
             { title: 'doc2', type: 'doc' },
@@ -318,17 +320,17 @@ describe('test/mongo.test.js', () => {
         })
     );
 
-    afterEach(async () => await app.mongo.deleteMany(NAME, {}));
+    afterEach(async () => await app.mongo.get('test').deleteMany(NAME, {}));
 
     it('should delete success', async () => {
-      const result = await app.mongo.deleteMany(NAME, {
+      const result = await app.mongo.get('test').deleteMany(NAME, {
         filter: { type: 'doc' },
       });
       assert(result === 2);
     });
 
     it('should delete all success', async () => {
-      const result = await app.mongo.deleteMany(NAME);
+      const result = await app.mongo.get('test').deleteMany(NAME);
       assert(result === 4);
     });
   });
@@ -336,7 +338,7 @@ describe('test/mongo.test.js', () => {
   describe('find()', () => {
     beforeEach(
       async () =>
-        await app.mongo.insertMany(NAME, {
+        await app.mongo.get('test').insertMany(NAME, {
           docs: [
             { index: 1, type: 'doc' },
             { index: 2, type: 'doc' },
@@ -346,7 +348,7 @@ describe('test/mongo.test.js', () => {
     );
 
     it('should find success', async () => {
-      const result = await app.mongo.find(NAME, {
+      const result = await app.mongo.get('test').find(NAME, {
         query: { type: 'doc' },
       });
       assert(Array.isArray(result));
@@ -354,31 +356,31 @@ describe('test/mongo.test.js', () => {
     });
 
     it('should find success with limit', async () => {
-      const result = await app.mongo.find(NAME, { limit: 1 });
+      const result = await app.mongo.get('test').find(NAME, { limit: 1 });
       assert(Array.isArray(result));
       assert(result.length === 1);
     });
 
     it('should find success with skip', async () => {
-      const result = await app.mongo.find(NAME, { skip: 1 });
+      const result = await app.mongo.get('test').find(NAME, { skip: 1 });
       assert(Array.isArray(result));
       assert(result.length === 2);
     });
 
     it('should find success with project', async () => {
-      const result = await app.mongo.find(NAME, { project: { index: 1 } });
+      const result = await app.mongo.get('test').find(NAME, { project: { index: 1 } });
       assert(result[0].hasOwnProperty('index'));
       assert(!result[0].hasOwnProperty('type'));
     });
 
     it('should find success with sort', async () => {
-      const result = await app.mongo.find(NAME, { sort: { index: -1 } });
+      const result = await app.mongo.get('test').find(NAME, { sort: { index: -1 } });
       assert(result[0].index > result[1].index);
       assert(result[1].index > result[2].index);
     });
 
     it('should find success with empty args', async () => {
-      const result = await app.mongo.find(NAME);
+      const result = await app.mongo.get('test').find(NAME);
       assert(Array.isArray(result));
       assert(result.length === 3);
     });
@@ -387,7 +389,7 @@ describe('test/mongo.test.js', () => {
   describe('count()', () => {
     beforeEach(
       async () =>
-        await app.mongo.insertMany(NAME, {
+        await app.mongo.get('test').insertMany(NAME, {
           docs: [
             { type: 'doc' },
             { type: 'doc' },
@@ -398,14 +400,14 @@ describe('test/mongo.test.js', () => {
     );
 
     it('should count success', async () => {
-      const result = await app.mongo.count(NAME, {
+      const result = await app.mongo.get('test').count(NAME, {
         query: { type: 'doc' },
       });
       assert(result === 2);
     });
 
     it('should count all success', async () => {
-      const result = await app.mongo.count(NAME);
+      const result = await app.mongo.get('test').count(NAME);
       assert(result === 4);
     });
   });
@@ -413,7 +415,7 @@ describe('test/mongo.test.js', () => {
   describe('distinct()', () => {
     beforeEach(
       async () =>
-        await app.mongo.insertMany(NAME, {
+        await app.mongo.get('test').insertMany(NAME, {
           docs: [
             { type: 'doc' },
             { type: 'doc' },
@@ -424,7 +426,7 @@ describe('test/mongo.test.js', () => {
     );
 
     it('should distinct success', async () => {
-      const result = await app.mongo.distinct(NAME, {
+      const result = await app.mongo.get('test').distinct(NAME, {
         key: 'type',
       });
       assert(Array.isArray(result));
@@ -432,7 +434,7 @@ describe('test/mongo.test.js', () => {
     });
 
     it('should distince success with query', async () => {
-      const result = await app.mongo.distinct(NAME, {
+      const result = await app.mongo.get('test').distinct(NAME, {
         key: 'type',
         query: { type: 'doc' },
       });
@@ -441,21 +443,21 @@ describe('test/mongo.test.js', () => {
     });
 
     it('should distince success with no key', async () => {
-      const result = await app.mongo.distinct(NAME);
+      const result = await app.mongo.get('test').distinct(NAME);
       assert.deepEqual(result, []);
     });
   });
 
   describe('createIndex()', () => {
     it('should create index success', async () => {
-      const result = await app.mongo.createIndex(NAME, {
+      const result = await app.mongo.get('test').createIndex(NAME, {
         fieldOrSpec: { title: -1 },
       });
       assert(result === 'title_-1');
     });
 
     it('should create index success', async () => {
-      const result = await app.mongo.createIndex(NAME, {
+      const result = await app.mongo.get('test').createIndex(NAME, {
         fieldOrSpec: 'title',
       });
       assert(result === 'title_1');
@@ -463,7 +465,7 @@ describe('test/mongo.test.js', () => {
 
     it('should create index fail with empty keys', async () => {
       try {
-        await app.mongo.createIndex(NAME, { fieldOrSpec: {} });
+        await app.mongo.get('test').createIndex(NAME, { fieldOrSpec: {} });
       } catch (error) {
         assert(error instanceof Error);
       }
@@ -471,7 +473,7 @@ describe('test/mongo.test.js', () => {
 
     it('should create index fail with empty args', async () => {
       try {
-        await app.mongo.createIndex(NAME);
+        await app.mongo.get('test').createIndex(NAME);
       } catch (error) {
         assert(error instanceof Error);
       }
@@ -480,14 +482,14 @@ describe('test/mongo.test.js', () => {
 
   describe('createCollection() && listCollections()', () => {
     it('should create && list collection success', async () => {
-      await app.mongo.createCollection({ name: 'create' });
-      const result = await app.mongo.listCollections();
+      await app.mongo.get('test').createCollection({ name: 'create' });
+      const result = await app.mongo.get('test').listCollections();
       assert(result.indexOf('create') !== -1);
     });
 
     it('should create fail with empty args', async () => {
       try {
-        await app.mongo.createCollection();
+        await app.mongo.get('test').createCollection();
       } catch (error) {
         assert(error instanceof Error);
       }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
remove ***client*** option in `config.default.js`, fixed ***AssertionError [ERR_ASSERTION]: egg:singleton mongo can not set options.client and options.clients both***